### PR TITLE
refactor: update parent user API URLs and expose serializer in Swagger

### DIFF
--- a/Girinie-backend/parent_users/serializers.py
+++ b/Girinie-backend/parent_users/serializers.py
@@ -7,7 +7,8 @@ class ParentUserSerializer(ModelSerializer):
     password = serializers.CharField(write_only=True)
     class Meta:
         model = ParentUser
-        fields = ('username', 'password', 'email', )
+        fields = ('id', 'username', 'password', 'email')
+        read_only_fields = ('id',)  # 응답에 id 포함하고 싶을 경우
 
     def create(self, validated_data):
         password = validated_data.pop('password')

--- a/Girinie-backend/parent_users/urls.py
+++ b/Girinie-backend/parent_users/urls.py
@@ -3,6 +3,6 @@ from .views import LoginView, LogoutView, UserCreateView, UserDeleteView
 urlpatterns = [
     path("login/", LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
-    path('users/', UserCreateView.as_view(), name='signup'),
-    path('users/me/', UserDeleteView.as_view(), name='delete-account'),
+    path('', UserCreateView.as_view(), name='signup'),
+    path('me/', UserDeleteView.as_view(), name='delete-account'),
 ]

--- a/Girinie-backend/parent_users/views.py
+++ b/Girinie-backend/parent_users/views.py
@@ -67,17 +67,9 @@ class UserCreateView(APIView):
     @swagger_auto_schema(
         operation_summary="회원가입",
         operation_description="새로운 사용자 등록. username, password, email 필요.",
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            required=['username', 'password', 'email'],
-            properties={
-                'username': openapi.Schema(type=openapi.TYPE_STRING, description='사용자 이름'),
-                'password': openapi.Schema(type=openapi.TYPE_STRING, description='비밀번호'),
-                'email': openapi.Schema(type=openapi.TYPE_STRING, description='이메일'),
-            }
-        ),
+        request_body=ParentUserSerializer,
         responses={
-            201: openapi.Response(description='회원가입 성공'),
+            201: ParentUserSerializer,
             400: openapi.Response(description='입력 오류'),
         }
     )


### PR DESCRIPTION
## 📌 [PR 제목](refactor: update parent user API URLs and expose serializer in Swagger)

## ✅ 작업 내용
- parent api url 좀 더 간결하게 수정
- swagger 문서에 ParentUser 모델 구조가 노출되도록 함
- api 요청 시 parent user의 아이디가 응답에 포함되도록 serializer 수정


📸 스크린샷 첨부(선택)

## 🔁 관련 이슈
- close #이슈번호
